### PR TITLE
Bug 722536 - Link test module in report view to the correct hg changeset

### DIFF
--- a/_attachments/js/dashboard.js
+++ b/_attachments/js/dashboard.js
@@ -28,6 +28,13 @@ function processTestResults(aReport) {
     // Split absolute path and only keep the relative path below the test-run folder
     var filename = result.filename.split(report_type)[1].replace(/\\/g, '/');
 
+    var repository_url = null;
+    if ('tests_repository' in aReport) {
+      repository_url = aReport.tests_repository + '/file/' +
+                       aReport.tests_changeset + '/tests/' +
+                       report_type + filename
+    }
+
     var status = "passed";
     if (result.skipped)
       status = "skipped";
@@ -66,6 +73,7 @@ function processTestResults(aReport) {
     }
 
     results.push({
+      repository_url : repository_url,
       filename : filename,
       test : result.name,
       status : status,

--- a/_attachments/templates/addons_report.mustache
+++ b/_attachments/templates/addons_report.mustache
@@ -90,7 +90,10 @@
         {{#results}}
         <tr class="{{status}}">
           <td>{{status}}</td>
-          <td>{{filename}}</td>
+          <td>
+            {{#repository_url}}<a href="{{repository_url}}">{{filename}}</a>{{/repository_url}}
+            {{^repository_url}}{{filename}}{{/repository_url}}
+          </td>
           <td>{{test}}</td>
           <td>
             <ul class="information">

--- a/_attachments/templates/endurance_report.mustache
+++ b/_attachments/templates/endurance_report.mustache
@@ -293,7 +293,10 @@
         {{#results}}
         <tr class="{{status}}">
           <td>{{status}}</td>
-          <td>{{filename}}</td>
+          <td>
+            {{#repository_url}}<a href="{{repository_url}}">{{filename}}</a>{{/repository_url}}
+            {{^repository_url}}{{filename}}{{/repository_url}}
+          </td>
           <td>{{test}}</td>
           <td>
             <ul class="information">

--- a/_attachments/templates/functional_report.mustache
+++ b/_attachments/templates/functional_report.mustache
@@ -74,7 +74,10 @@
         {{#results}}
         <tr class="{{status}}">
           <td>{{status}}</td>
-          <td>{{filename}}</td>
+          <td>
+            {{#repository_url}}<a href="{{repository_url}}">{{filename}}</a>{{/repository_url}}
+            {{^repository_url}}{{filename}}{{/repository_url}}
+          </td>
           <td>{{test}}</td>
           <td>
             <ul class="information">

--- a/_attachments/templates/l10n_report.mustache
+++ b/_attachments/templates/l10n_report.mustache
@@ -74,7 +74,10 @@
         {{#results}}
         <tr class="{{status}}">
           <td>{{status}}</td>
-          <td>{{filename}}</td>
+          <td>
+            {{#repository_url}}<a href="{{repository_url}}">{{filename}}</a>{{/repository_url}}
+            {{^repository_url}}{{filename}}{{/repository_url}}
+          </td>
           <td>{{test}}</td>
           <td>
             <ul class="information">

--- a/_attachments/templates/remote_report.mustache
+++ b/_attachments/templates/remote_report.mustache
@@ -74,7 +74,10 @@
         {{#results}}
         <tr class="{{status}}">
           <td>{{status}}</td>
-          <td>{{filename}}</td>
+          <td>
+            {{#repository_url}}<a href="{{repository_url}}">{{filename}}</a>{{/repository_url}}
+            {{^repository_url}}{{filename}}{{/repository_url}}
+          </td>
           <td>{{test}}</td>
           <td>
             <ul class="information">

--- a/_attachments/templates/update_report.mustache
+++ b/_attachments/templates/update_report.mustache
@@ -143,7 +143,10 @@
         {{#results}}
         <tr class="{{status}}">
           <td>{{status}}</td>
-          <td>{{filename}}</td>
+          <td>
+            {{#repository_url}}<a href="{{repository_url}}">{{filename}}</a>{{/repository_url}}
+            {{^repository_url}}{{filename}}{{/repository_url}}
+          </td>
           <td>{{test}}</td>
           <td>
             <ul class="information">


### PR DESCRIPTION
Adds links to the test file on hg.mozilla.org if repository url and changeset are present in the report.
