### PR TITLE
Use average instead of max for reporting memory.

### DIFF
--- a/_attachments/templates/endurance_charts.mustache
+++ b/_attachments/templates/endurance_charts.mustache
@@ -81,7 +81,7 @@
           borderColor: '#AAAAAA',
           borderRadius: 10,
           borderWidth: 1,
-          renderTo: 'max-explicit-chart',
+          renderTo: 'average-explicit-chart',
           defaultSeriesType: 'line'
         },
         plotOptions: {
@@ -98,11 +98,11 @@
           name: "{{name}}",
           data: [
             {{#reports}}
-              [Date.parse("{{time_start}}"), {{#memory}}{{#explicit}}{{max}}{{/explicit}}{{^explicit}}""{{/explicit}}{{/memory}}],
+              [Date.parse("{{time_start}}"), {{#memory}}{{#explicit}}{{average}}{{/explicit}}{{^explicit}}""{{/explicit}}{{/memory}}],
             {{/reports}}],
         },{{/platform_reports}}],
         title: {
-          text: 'Max Explicit Memory'
+          text: 'Average Explicit Memory'
         },
         xAxis: {
           type: 'datetime'
@@ -119,7 +119,7 @@
           borderColor: '#AAAAAA',
           borderRadius: 10,
           borderWidth: 1,
-          renderTo: 'max-resident-chart',
+          renderTo: 'average-resident-chart',
           defaultSeriesType: 'line'
         },
         plotOptions: {
@@ -136,11 +136,11 @@
           name: "{{name}}",
           data: [
             {{#reports}}
-              [Date.parse("{{time_start}}"), {{#memory}}{{#resident}}{{max}}{{/resident}}{{^resident}}""{{/resident}}{{/memory}}],
+              [Date.parse("{{time_start}}"), {{#memory}}{{#resident}}{{average}}{{/resident}}{{^resident}}""{{/resident}}{{/memory}}],
             {{/reports}}],
         },{{/platform_reports}}],
         title: {
-          text: 'Max Resident Memory'
+          text: 'Average Resident Memory'
         },
         xAxis: {
           type: 'datetime'
@@ -193,5 +193,5 @@
 
     <div id="test-result-chart" class="chart" style="float:left"></div>
     <div id="duration-chart" class="chart"></div>
-    <div id="max-explicit-chart" class="chart" style="float:left"></div>
-    <div id="max-resident-chart" class="chart"></div>
+    <div id="average-explicit-chart" class="chart" style="float:left"></div>
+    <div id="average-resident-chart" class="chart"></div>

--- a/_attachments/templates/endurance_reports.mustache
+++ b/_attachments/templates/endurance_reports.mustache
@@ -29,22 +29,19 @@
     <table id="results">
       <thead>
         <tr>
-          <th rowspan="2">Date</th>
-          <th rowspan="2">Version</th>
-          <th rowspan="2">Build</th>
-          <th rowspan="2">Locale</th>
-          <th rowspan="2">Platform</th>
-          <th rowspan="2">Version</th>
-          <th rowspan="2">CPU</th>
-          <th rowspan="2">Delay (s)</th>
-          <th rowspan="2"># Iterations</th>
-          <th colspan="2" title="Explicit">Memory (MB)</th>
-          <th rowspan="2"># Pass</th>
-          <th rowspan="2"># Skip</th>
-          <th rowspan="2"># Fail</th>
-        </tr><tr>
-          <th>min</th>
-          <th>max</th>
+          <th>Date</th>
+          <th>Version</th>
+          <th>Build</th>
+          <th>Locale</th>
+          <th>Platform</th>
+          <th>Version</th>
+          <th>CPU</th>
+          <th>Delay (s)</th>
+          <th># Iterations</th>
+          <th title="Explicit (Average)">Memory (MB)</th>
+          <th># Pass</th>
+          <th># Skip</th>
+          <th># Fail</th>
         </tr>
       </thead>
       <tbody>
@@ -59,8 +56,7 @@
           <td>{{processor}}</td>
           <td class="results">{{delay}}</td>
           <td class="results">{{iterations}}</td>
-          <td class="results">{{#memory}}{{#explicit}}{{min}}{{/explicit}}{{/memory}}</td>
-          <td class="results">{{#memory}}{{#explicit}}{{max}}{{/explicit}}{{/memory}}</td>
+          <td class="results">{{#memory}}{{#explicit}}{{average}}{{/explicit}}{{/memory}}</td>
           <td class="results">{{tests_passed}}</td>
           <td class="results">{{tests_skipped}}</td>
           <td class="results">{{tests_failed}}</td>


### PR DESCRIPTION
This switches the endurance tests to use average memory metrics instead of max for the summary reports and charts.
