### PR TITLE
Update Firefox version for 28.0 release

### DIFF
--- a/_attachments/js/config.js
+++ b/_attachments/js/config.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var FIREFOX_VERSIONS = ["28.0", "27.0", "26.0", "25.0", "24.0"];
+var FIREFOX_VERSIONS = ["28.0", "27.0", "26.0", "25.0", "24.0", "17.0"];
 var TESTS_REPOSITORY = "http://hg.mozilla.org/qa/mozmill-tests";
 
 var DASHBOARD_SERVERS = [


### PR DESCRIPTION
Pull request for review.

We have a one-week overlap of both ESR 24 and ESR 17 releases as discussed on IRC, so there are six fields in this change instead of the usual five.
