### PR TITLE
Fix linkfication of tests for the mozmill-tests refactoring and workspace feature (#73)

### DIFF
--- a/_attachments/js/dashboard.js
+++ b/_attachments/js/dashboard.js
@@ -54,10 +54,11 @@ function processTestResults(aReport) {
     var info = [ ];
 
     // Split absolute path and only keep the relative path below the test-run folder
-    var filename = result.filename.split(report_type)[1].replace(/\\/g, '/');
+    var parts = result.filename.split(report_type)
+    var filename = parts[parts.length - 1].replace(/\\/g, '/');
 
     var repository_url = TESTS_REPOSITORY + '/file/' +
-                         aReport.tests_changeset + '/tests/' +
+                         aReport.tests_changeset + '/firefox/tests/' +
                          report_type + filename;
 
     var status = "passed";
@@ -84,7 +85,7 @@ function processTestResults(aReport) {
         var failure = result.fails[j];
         var message = "Unknown Failure";
         var stack = null;
-  
+
         if ("exception" in failure) {
           // An exception has been thrown
           message = failure.exception.message;
@@ -1222,7 +1223,7 @@ function processTestResults(aReport) {
 
         var template = '/templates/endurance_charts.mustache';
         context.render(template).replace('#content').then(function () {
-          
+
           $('#branch-selection span').each(function (i, elem) {
             if (elem.textContent == branch) {
               $(elem).addClass("selected")
@@ -1259,7 +1260,7 @@ function processTestResults(aReport) {
                               '&from=' + $("#start-date").val() +
                               '&to=' + $("#end-date").val();
           })
-          
+
           $("#subtitle").text("Endurance Charts");
         });
       });
@@ -1342,7 +1343,7 @@ function processTestResults(aReport) {
                 if (tests[i].iterations[j].checkpoints[k].explicit) {
                   checkpointMemory.explicit = Math.round(tests[i].iterations[j].checkpoints[k].explicit * BYTE_TO_MEGABYTE);
                 }
-    
+
                 if (tests[i].iterations[j].checkpoints[k].resident) {
                   checkpointMemory.resident = Math.round(tests[i].iterations[j].checkpoints[k].resident * BYTE_TO_MEGABYTE);
                 }
@@ -1432,7 +1433,7 @@ function processTestResults(aReport) {
             average : Math.round(stats.explicit.average * BYTE_TO_MEGABYTE)
           }
         }
-  
+
         if ("resident" in stats) {
           memory.resident = {
             min : Math.round(stats.resident.min * BYTE_TO_MEGABYTE),


### PR DESCRIPTION
This fixes the issue as reported in issue #73. I pushed this change to staging for reference and testing:

http://mozmill-staging.blargon7.com/#/functional/report/456bebe92845279408c15c03e8c43b7e

I'm not sure if it makes sense to keep backward compatibility, given that reports will be outdated kinda quickly and not needed anymore.
