### PR TITLE
Update Firefox version for 29.0 release

### DIFF
--- a/_attachments/js/config.js
+++ b/_attachments/js/config.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var FIREFOX_VERSIONS = ["28.0", "27.0", "26.0", "25.0", "24.0", "17.0"];
+var FIREFOX_VERSIONS = ["29.0", "28.0", "27.0", "26.0", "24.0"];
 var TESTS_REPOSITORY = "http://hg.mozilla.org/qa/mozmill-tests";
 
 var DASHBOARD_SERVERS = [


### PR DESCRIPTION
Pull request for review.

As mentioned in the related issue, esr17 will no longer be supported starting Dec 9th, so it has been removed.

Adding @whimboo for visibility.
