### PR TITLE
Use CSS to show submenus instead of JS, and disable any animation (#77)

### DIFF
--- a/_attachments/css/main.css
+++ b/_attachments/css/main.css
@@ -67,18 +67,21 @@ ul.topnav li a:hover {
 ul.topnav li ul.subnav {
   list-style: none;
   position: absolute;
-  left: 0;
+  left: -9999px;
   top: 31px;
   background: url(/img/testrun_bg.png) repeat-x;
   margin: 0;
   padding: 0;
-  display: none;
   float: left;
   width: 170px;
   -moz-border-radius-bottomleft: 5px;
   -moz-border-radius-bottomright: 5px;
   -webkit-border-bottom-left-radius: 5px;
   -webkit-border-bottom-right-radius: 5px;
+}
+
+ul.topnav li:hover ul.subnav {
+  left: 0;
 }
 
 ul.topnav li ul.subnav li{

--- a/_attachments/index.html
+++ b/_attachments/index.html
@@ -27,22 +27,6 @@
         if (titleName !== "") {
           $("#title").html(titleName);
         }
-        $("ul.topnav li a").hover(function () {
-          //Following events are applied to the subnav itself (moving subnav up and down)
-          $(this).parent().find("ul.subnav").slideDown('fast').show();
-          $(this).parent().hover(function () {
-          }, function (){
-            //When the mouse hovers out of the subnav, move it back up
-            $(this).parent().find("ul.subnav").slideUp('slow');
-          });
-
-        // Following events are applied to the trigger (Hover events for the trigger)
-        }).hover(function () {
-          $(this).addClass("subhover");
-        }, function () {
-          //On Hover Out
-          $(this).removeClass("subhover");
-        });
       });
     </script>
   </head>


### PR DESCRIPTION
Moved the hide/show logic for the submenu from JS to the CSS.
And removed any animations.

This makes it faster and more robust.

@whimboo or @davehunt please have a look.
Thanks
