### PR TITLE
Switched from 'Windows NT' to 'Win' as OS identifier (#79)

### DIFF
--- a/_attachments/templates/addons_reports.mustache
+++ b/_attachments/templates/addons_reports.mustache
@@ -13,7 +13,7 @@
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
-        <span>Windows NT</span>
+        <span>Win</span>
       </div>
 
       <div id="date">

--- a/_attachments/templates/endurance_charts.mustache
+++ b/_attachments/templates/endurance_charts.mustache
@@ -12,7 +12,7 @@
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
-        <span>Windows NT</span>
+        <span>Win</span>
       </div>
 
       <div id="date">

--- a/_attachments/templates/endurance_reports.mustache
+++ b/_attachments/templates/endurance_reports.mustache
@@ -13,7 +13,7 @@
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
-        <span>Windows NT</span>
+        <span>Win</span>
       </div>
 
       <div id="date">

--- a/_attachments/templates/functional_failure.mustache
+++ b/_attachments/templates/functional_failure.mustache
@@ -13,7 +13,7 @@
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
-        <span>Windows NT</span>
+        <span>Win</span>
       </div>
 
       <div id="date">

--- a/_attachments/templates/functional_failures.mustache
+++ b/_attachments/templates/functional_failures.mustache
@@ -13,7 +13,7 @@
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
-        <span>Windows NT</span>
+        <span>Win</span>
       </div>
 
       <div id="date">

--- a/_attachments/templates/functional_reports.mustache
+++ b/_attachments/templates/functional_reports.mustache
@@ -13,7 +13,7 @@
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
-        <span>Windows NT</span>
+        <span>Win</span>
       </div>
 
       <div id="date">

--- a/_attachments/templates/l10n_reports.mustache
+++ b/_attachments/templates/l10n_reports.mustache
@@ -13,7 +13,7 @@
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
-        <span>Windows NT</span>
+        <span>Win</span>
       </div>
 
       <div id="date">

--- a/_attachments/templates/remote_reports.mustache
+++ b/_attachments/templates/remote_reports.mustache
@@ -13,7 +13,7 @@
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
-        <span>Windows NT</span>
+        <span>Win</span>
       </div>
 
       <div id="date">

--- a/_attachments/templates/update_reports.mustache
+++ b/_attachments/templates/update_reports.mustache
@@ -13,7 +13,7 @@
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
-        <span>Windows NT</span>
+        <span>Win</span>
       </div>
 
       <div id="date">


### PR DESCRIPTION
Switched to using the new identifier 'Win'
No point in keeping the old one.

Tested this on the sandbox server:
http://mozmill-sandbox.blargon7.com/#/l10n/reports?branch=All&platform=All&from=2013-12-31&to=2014-01-03

@whimboo please have a look.
