### PR TITLE
Add support for Metro testrun (#47)

### DIFF
--- a/_attachments/templates/addons_reports.mustache
+++ b/_attachments/templates/addons_reports.mustache
@@ -1,5 +1,13 @@
     <fieldset id="filter">
       <legend>Filter</legend>
+
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>
@@ -30,6 +38,7 @@
       <thead>
         <tr>
           <th>Date</th>
+          <th>Application</th>
           <th>Version</th>
           <th>Build</th>
           <th>Locale</th>
@@ -46,6 +55,7 @@
       {{#reports}}
         <tr>
           <td><a href="{{report_link}}">{{time_start}}</a></td>
+          <td>{{application_name}}</td>
           <td>{{application_version}}</td>
           <td>{{build_id}}</td>
           <td>{{locale}}</td>

--- a/_attachments/templates/endurance_charts.mustache
+++ b/_attachments/templates/endurance_charts.mustache
@@ -1,7 +1,16 @@
     <fieldset id="filter">
       <legend>Filter</legend>
+
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
+        <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
         {{/firefox_versions}}

--- a/_attachments/templates/endurance_reports.mustache
+++ b/_attachments/templates/endurance_reports.mustache
@@ -1,5 +1,13 @@
     <fieldset id="filter">
       <legend>Filter</legend>
+
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>
@@ -30,6 +38,7 @@
       <thead>
         <tr>
           <th>Date</th>
+          <th>Application</th>
           <th>Version</th>
           <th>Build</th>
           <th>Locale</th>
@@ -48,6 +57,7 @@
       {{#reports}}
         <tr>
           <td><a href="{{report_link}}">{{time_start}}</a></td>
+          <td>{{application_name}}</td>
           <td>{{application_version}}</td>
           <td>{{build_id}}</td>
           <td>{{locale}}</td>

--- a/_attachments/templates/functional_failure.mustache
+++ b/_attachments/templates/functional_failure.mustache
@@ -1,5 +1,13 @@
     <fieldset id="filter">
       <legend>Filter</legend>
+
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>
@@ -30,6 +38,7 @@
       <thead>
         <tr>
           <th>Date</th>
+          <th>Application</th>
           <th>Version</th>
           <th>Platform</th>
           <th>Locale</th>
@@ -41,6 +50,7 @@
       {{#reports}}
         <tr>
           <td><a href="{{report_link}}">{{time_start}}</a></td>
+          <td>{{application_name}}</td>
           <td>{{application_version}} ({{platform_buildId}})</td>
           <td>{{system_name}} {{system_version}}</td>
           <td>{{application_locale}}</td>

--- a/_attachments/templates/functional_failures.mustache
+++ b/_attachments/templates/functional_failures.mustache
@@ -1,5 +1,13 @@
     <fieldset id="filter">
       <legend>Filter</legend>
+
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>
@@ -31,6 +39,7 @@
         <tr>
           <th>Module</th>
           <th>Function</th>
+          <th>Application</th>
           <th>Branch</th>
           <th>Platform</th>
           <th># Fail</th>
@@ -42,6 +51,7 @@
         <tr>
           <td>{{test_module}}</td>
           <td><a href="{{failure_link}}">{{test_function}}</a></td>
+          <td>{{application_name}}</td>
           <td>{{application_branch}}</td>
           <td>{{system_name}}</td>
           <td>{{failure_count}}</td>

--- a/_attachments/templates/functional_reports.mustache
+++ b/_attachments/templates/functional_reports.mustache
@@ -1,5 +1,13 @@
     <fieldset id="filter">
       <legend>Filter</legend>
+
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>
@@ -30,6 +38,7 @@
       <thead>
         <tr>
           <th>Date</th>
+          <th>Application</th>
           <th>Version</th>
           <th>Build</th>
           <th>Locale</th>
@@ -45,6 +54,7 @@
       {{#reports}}
         <tr>
           <td><a href="{{report_link}}">{{time_start}}</a></td>
+          <td>{{application_name}}</td>
           <td>{{application_version}}</td>
           <td>{{build_id}}</td>
           <td>{{locale}}</td>

--- a/_attachments/templates/l10n_reports.mustache
+++ b/_attachments/templates/l10n_reports.mustache
@@ -1,5 +1,13 @@
     <fieldset id="filter">
       <legend>Filter</legend>
+
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>
@@ -30,6 +38,7 @@
       <thead>
         <tr>
           <th>Date</th>
+          <th>Application</th>
           <th>Version</th>
           <th>Build</th>
           <th>Locale</th>
@@ -45,6 +54,7 @@
       {{#reports}}
         <tr>
           <td><a href="{{report_link}}">{{time_start}}</a></td>
+          <td>{{application_name}}</td>
           <td>{{application_version}}</td>
           <td>{{build_id}}</td>
           <td>{{locale}}</td>

--- a/_attachments/templates/remote_failure.mustache
+++ b/_attachments/templates/remote_failure.mustache
@@ -1,5 +1,13 @@
     <fieldset id="filter">
       <legend>Filter</legend>
+
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>
@@ -13,7 +21,7 @@
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
-        <span>Windows NT</span>
+        <span>Win</span>
       </div>
 
       <div id="date">
@@ -30,6 +38,7 @@
       <thead>
         <tr>
           <th>Date</th>
+          <th>Application</th>
           <th>Version</th>
           <th>Platform</th>
           <th>Locale</th>
@@ -41,6 +50,7 @@
       {{#reports}}
         <tr>
           <td><a href="{{report_link}}">{{time_start}}</a></td>
+          <td>{{application_name}}</td>
           <td>{{application_version}} ({{platform_buildId}})</td>
           <td>{{system_name}} {{system_version}}</td>
           <td>{{application_locale}}</td>

--- a/_attachments/templates/remote_failures.mustache
+++ b/_attachments/templates/remote_failures.mustache
@@ -1,5 +1,13 @@
     <fieldset id="filter">
       <legend>Filter</legend>
+
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>
@@ -13,7 +21,7 @@
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
-        <span>Windows NT</span>
+        <span>Win</span>
       </div>
 
       <div id="date">
@@ -31,6 +39,7 @@
         <tr>
           <th>Module</th>
           <th>Function</th>
+          <th>Application</th>
           <th>Branch</th>
           <th>Platform</th>
           <th># Fail</th>
@@ -42,6 +51,7 @@
         <tr>
           <td>{{test_module}}</td>
           <td><a href="{{failure_link}}">{{test_function}}</a></td>
+          <td>{{application_name}}</td>
           <td>{{application_branch}}</td>
           <td>{{system_name}}</td>
           <td>{{failure_count}}</td>

--- a/_attachments/templates/remote_reports.mustache
+++ b/_attachments/templates/remote_reports.mustache
@@ -1,5 +1,13 @@
     <fieldset id="filter">
       <legend>Filter</legend>
+
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>
@@ -30,6 +38,7 @@
       <thead>
         <tr>
           <th>Date</th>
+          <th>Application</th>
           <th>Version</th>
           <th>Build</th>
           <th>Locale</th>
@@ -45,6 +54,7 @@
       {{#reports}}
         <tr>
           <td><a href="{{report_link}}">{{time_start}}</a></td>
+          <td>{{application_name}}</td>
           <td>{{application_version}}</td>
           <td>{{build_id}}</td>
           <td>{{locale}}</td>

--- a/_attachments/templates/update_overview.mustache
+++ b/_attachments/templates/update_overview.mustache
@@ -1,6 +1,13 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/update_reports.mustache
+++ b/_attachments/templates/update_reports.mustache
@@ -1,5 +1,13 @@
     <fieldset id="filter">
       <legend>Filter</legend>
+
+      <div id="app-selection">
+        <span>Application: </span>
+        <span>All</span>
+        <span>Firefox</span>
+        <span>MetroFirefox</span>
+      </div>
+
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>
@@ -30,6 +38,7 @@
       <thead>
         <tr>
           <th>Date</th>
+          <th>Application</th>
           <th>Version</th>
           <th>Build</th>
           <th>Locale</th>
@@ -45,6 +54,7 @@
       {{#reports}}
         <tr>
           <td><a href="{{report_link}}">{{time_start}}</a></td>
+          <td>{{application_name}}</td>
           <td>{{application_version}}</td>
           <td>{{build_id}}</td>
           <td>{{locale}}</td>


### PR DESCRIPTION
And we have support for Metro testruns.

I added support for the Metro Application ID and created a new section (based on the Functional testrun).
- I took out all OS information from the Filters since it doesn't make any sense here

You can see it on the sandbox server:
http://mozmill-sandbox.blargon7.com/#/metro/reports

@whimboo please review. Thanks.
