### PR TITLE
Fix error tooltip(#83)

### DIFF
--- a/_attachments/css/main.css
+++ b/_attachments/css/main.css
@@ -106,7 +106,6 @@ html ul.topnav li ul.subnav li a:hover {
 }
 
 #content {
-  width: 90%;
   margin: 0 auto;
   padding-top: 10px;
   clear: both;
@@ -230,6 +229,10 @@ table#graphics {
   margin: 10px 0 0 0;
 }
 
+#result td:last-child {
+  min-width: 38em;
+}
+
 table#results td, table#results th {
   margin: 0;
 }
@@ -264,25 +267,36 @@ table#result tr.skipped td {
   color: #f90;
 }
 
-.tooltip {
-  display: none;
-}
-
 table .information {
   vertical-align: top;
   margin: 0;
   padding: 0 10px;
 }
 
-table#result tr.failed .information:hover .tooltip {
-  position: absolute;
+.tooltip {
+  background: rgb(243, 243, 243);
+  border: 1px solid rgb(216, 213, 213);
+  border-radius: 4px;
+  box-shadow: 0 0 5px 0 rgb(191, 189, 189);
+  display: none;
+  font-size: 1.2em;
+  font-family: monospace;
+  margin: 1em 0;
+  padding: .5em 1em;
+  white-space: pre;
+}
+
+.tooltip div {
+  overflow: auto;
+  max-width: 35em;
+  max-height: 30em;
+}
+
+.tooltip.active {
   display: block;
-  overflow: scroll;
-  width: 400px;
-  border: 1px solid #333;
-  -moz-border-radius: 10px;
-  padding: 5px 10px;
-  background-color: #fff;
+}
+.show-tooltip {
+  font-size: 0.8em;
 }
 
 th.headerSortUp {

--- a/_attachments/js/dashboard.js
+++ b/_attachments/js/dashboard.js
@@ -94,19 +94,24 @@ function processTestResults(aReport) {
           // An exception has been thrown
           message = failure.exception.message;
           stack = failure.exception.stack;
+          if (stack instanceof Array) {
+            stack = stack.map(function (item, i) {
+              return ((i === 0) ? "" : "\n") + item;
+            });
+            stack = { stack: stack };
+          }
         }
         else if ("fail" in failure) {
           // An assertion failed
           message = failure.fail.message;
           if ("stack" in failure.fail) {
-            stack = JSON.stringify(failure.fail.stack);
+            stack = JSON.stringify(failure.fail.stack, null, " ");
           }
         }
         else if ("message" in failure) {
           // A plain JS error has been reported
           message = failure.message;
         }
-
         info.push({message: message, stack: stack});
       }
     }
@@ -2273,4 +2278,20 @@ function processTestResults(aReport) {
     app.run('#/functional');
   });
 
+})(jQuery);
+
+/**
+ * Toggle error tooltips
+ */
+(function($) {
+  $(document).bind('click', function (e) {
+    var target = $(e.target);
+    if (target.is('.show-tooltip')) {
+      var tooltip = target.next('.tooltip');
+      tooltip.toggleClass('active');
+      target.text(tooltip.is('.active') ? 'show less' : 'show more');
+      e.preventDefault();
+      return false;
+    }
+  });
 })(jQuery);

--- a/_attachments/templates/addons_report.mustache
+++ b/_attachments/templates/addons_report.mustache
@@ -100,7 +100,10 @@
             {{#info}}
               <li>
                 {{{message}}}
-                {{#stack}}<div class="tooltip">{{{stack}}}<div>{{/stack}}
+                {{#stack}}
+                  <a href="#" class="show-tooltip">show more</a>
+                  <div class="tooltip"><div>{{{stack}}}</div></div>
+                {{/stack}}
               </li>
             {{/info}}
             </ul>
@@ -110,4 +113,3 @@
       </tbody>
     </table>
   </body>
-

--- a/_attachments/templates/endurance_report.mustache
+++ b/_attachments/templates/endurance_report.mustache
@@ -303,7 +303,10 @@
             {{#info}}
               <li>
                 {{{message}}}
-                {{#stack}}<div class="tooltip">{{{stack}}}<div>{{/stack}}
+                {{#stack}}
+                  <a href="#" class="show-tooltip">show more</a>
+                  <div class="tooltip"><div>{{{stack}}}</div></div>
+                {{/stack}}
               </li>
             {{/info}}
             </ul>
@@ -314,4 +317,3 @@
     </table>
 
   </body>
-

--- a/_attachments/templates/functional_report.mustache
+++ b/_attachments/templates/functional_report.mustache
@@ -84,7 +84,10 @@
             {{#info}}
               <li>
                 {{{message}}}
-                {{#stack}}<div class="tooltip">{{{stack}}}<div>{{/stack}}
+                {{#stack}}
+                  <a href="#" class="show-tooltip">show more</a>
+                  <div class="tooltip"><div>{{{stack}}}</div></div>
+                {{/stack}}
               </li>
             {{/info}}
             </ul>
@@ -94,4 +97,3 @@
       </tbody>
     </table>
   </body>
-

--- a/_attachments/templates/l10n_report.mustache
+++ b/_attachments/templates/l10n_report.mustache
@@ -84,7 +84,10 @@
             {{#info}}
               <li>
                 {{{message}}}
-                {{#stack}}<div class="tooltip">{{{stack}}}<div>{{/stack}}
+                {{#stack}}
+                  <a href="#" class="show-tooltip">show more</a>
+                  <div class="tooltip"><div>{{{stack}}}</div></div>
+                {{/stack}}
               </li>
             {{/info}}
             </ul>

--- a/_attachments/templates/remote_report.mustache
+++ b/_attachments/templates/remote_report.mustache
@@ -84,7 +84,10 @@
             {{#info}}
               <li>
                 {{{message}}}
-                {{#stack}}<div class="tooltip">{{{stack}}}<div>{{/stack}}
+                {{#stack}}
+                  <a href="#" class="show-tooltip">show more</a>
+                  <div class="tooltip"><div>{{{stack}}}</div></div>
+                {{/stack}}
               </li>
             {{/info}}
             </ul>
@@ -94,4 +97,3 @@
       </tbody>
     </table>
   </body>
-

--- a/_attachments/templates/update_report.mustache
+++ b/_attachments/templates/update_report.mustache
@@ -153,7 +153,10 @@
             {{#info}}
               <li>
                 {{{message}}}
-                {{#stack}}<div class="tooltip">{{{stack}}}<div>{{/stack}}
+                {{#stack}}
+                  <a href="#" class="show-tooltip">show more</a>
+                  <div class="tooltip"><div>{{{stack}}}</div></div>
+                {{/stack}}
               </li>
             {{/info}}
             </ul>
@@ -163,4 +166,3 @@
       </tbody>
     </table>
   </body>
-


### PR DESCRIPTION
This fixes the problem we were having showing some errors.

In case of an exception, if we receive an array, we'll join the array with a <br> and send that forward to the template.

In the template we would draw a different "tooltip" for each "stack" message. This never worked correctly as they would overlap eachother. I've changed this to only have 1 tooltip per error, and show the stack inside.

In case of a failure we jsonify the result so this works nicely. Further down the line we might want to improve the look of this JSON object by also prettifying it. But thats another issue.

I've also improved and cleaned up the CSS a bit for the tooltip, and put up a monospaced font to make it look more like a console output.

Demo: http://mozmill-sandbox.blargon7.com/#/remote/report/40742e0746fd767e6d2fd58659a6dd52

@whimboo please review
