### PR TITLE
Always filter and report all esr runs (#86)

### DIFF
--- a/_attachments/js/config.js
+++ b/_attachments/js/config.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var FIREFOX_VERSIONS = ["29.0", "28.0", "27.0", "26.0", "24.0"];
+// Always filter for all esr builds in the last element
+var FIREFOX_VERSIONS = ["29.0", "28.0", "27.0", "26.0", "24"];
 var TESTS_REPOSITORY = "http://hg.mozilla.org/qa/mozmill-tests";
 
 var DASHBOARD_SERVERS = [


### PR DESCRIPTION
Pull request for review.

Henrik and I think this will successfully filter all esr24 runs; 24.0, 24.1, 24.2, etc. To be confirmed in sandbox. I've added a comment also, in case others later on are bumping the version numbers, and may think the .0 omission in the last element of the array is a mistake.

Adding @whimboo for visibility.
