### PR TITLE
Align filters via CSS (#90)

### DIFF
--- a/_attachments/css/main.css
+++ b/_attachments/css/main.css
@@ -113,7 +113,7 @@ html ul.topnav li ul.subnav li a:hover {
 
 #filter {
   width: 620px;
-  line-height: 20px;
+  line-height: 1.6em;
   text-align: left;
 }
 
@@ -138,7 +138,7 @@ html ul.topnav li ul.subnav li a:hover {
 #filter span:first-child {
   cursor: text;
   float: left;
-  width: 100px;
+  width: 6.1em;
 }
 
 #filter a.selected {


### PR DESCRIPTION
While reviewing #90 @tojonmz suggested in his commit https://github.com/tojonmz/mozmill-dashboard/commit/3801fcd2742461a9ec0554dd78c537198e1e5920 I should get credit for the CSS solution.

I don't really care about credit, but since I'll be unavailable for a few days, I should get this up.

cc @whimboo this fixes #90 with only CSS so we don't open the lions den to change markup (which will require JS changes as well due to tight coupling)

Also this is visible at: http://mozmill-sandbox.blargon7.com/
