### PR TITLE
Remove Application filter because MetroFirefox is discontinued (#104)

### DIFF
--- a/_attachments/templates/addons_reports.mustache
+++ b/_attachments/templates/addons_reports.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/endurance_charts.mustache
+++ b/_attachments/templates/endurance_charts.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/endurance_reports.mustache
+++ b/_attachments/templates/endurance_reports.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/functional_failure.mustache
+++ b/_attachments/templates/functional_failure.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/functional_failures.mustache
+++ b/_attachments/templates/functional_failures.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/functional_reports.mustache
+++ b/_attachments/templates/functional_reports.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/l10n_reports.mustache
+++ b/_attachments/templates/l10n_reports.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/remote_failure.mustache
+++ b/_attachments/templates/remote_failure.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/remote_failures.mustache
+++ b/_attachments/templates/remote_failures.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/remote_reports.mustache
+++ b/_attachments/templates/remote_reports.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/update_overview.mustache
+++ b/_attachments/templates/update_overview.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>

--- a/_attachments/templates/update_reports.mustache
+++ b/_attachments/templates/update_reports.mustache
@@ -1,13 +1,6 @@
     <fieldset id="filter">
       <legend>Filter</legend>
 
-      <div id="app-selection">
-        <span>Application: </span>
-        <span>All</span>
-        <span>Firefox</span>
-        <span>MetroFirefox</span>
-      </div>
-
       <div id="branch-selection">
         <span>Branch:</span>
         <span>All</span>


### PR DESCRIPTION
This fixes issue #104, removing the Application filter entirely as MetroFirefox has been discontinued. The existing metro support code in dashboard.js remains for now.

I tested all the menus in my local dashboard and it appears to be working as expected.

Adding @whimboo for visibility.
