### PR TITLE
Remove click events from Filter category labels (#102)

### DIFF
--- a/_attachments/css/main.css
+++ b/_attachments/css/main.css
@@ -135,10 +135,10 @@ html ul.topnav li ul.subnav li a:hover {
   padding: 0 5px;
 }
 
-#filter span:first-child {
-  cursor: text;
+#filter label {
   float: left;
   width: 6.1em;
+  padding: 0 5px;
 }
 
 #filter a.selected {

--- a/_attachments/templates/addons_reports.mustache
+++ b/_attachments/templates/addons_reports.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="os-selection">
-        <span>OS: </span>
+        <label>OS:</label>
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/endurance_charts.mustache
+++ b/_attachments/templates/endurance_charts.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="os-selection">
-        <span>OS: </span>
+        <label>OS:</label>
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/endurance_reports.mustache
+++ b/_attachments/templates/endurance_reports.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="os-selection">
-        <span>OS: </span>
+        <label>OS:</label>
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/functional_failure.mustache
+++ b/_attachments/templates/functional_failure.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="os-selection">
-        <span>OS: </span>
+        <label>OS:</label>
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/functional_failures.mustache
+++ b/_attachments/templates/functional_failures.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="os-selection">
-        <span>OS: </span>
+        <label>OS:</label>
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/functional_reports.mustache
+++ b/_attachments/templates/functional_reports.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="os-selection">
-        <span>OS: </span>
+        <label>OS:</label>
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/l10n_reports.mustache
+++ b/_attachments/templates/l10n_reports.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="os-selection">
-        <span>OS: </span>
+        <label>OS:</label>
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/remote_failure.mustache
+++ b/_attachments/templates/remote_failure.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="os-selection">
-        <span>OS: </span>
+        <label>OS:</label>
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/remote_failures.mustache
+++ b/_attachments/templates/remote_failures.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="os-selection">
-        <span>OS: </span>
+        <label>OS:</label>
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/remote_reports.mustache
+++ b/_attachments/templates/remote_reports.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="os-selection">
-        <span>OS: </span>
+        <label>OS:</label>
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/update_detail.mustache
+++ b/_attachments/templates/update_detail.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="channel-selection">
-        <span>Channel: </span>
+        <label>Channel:</label>
         <span>All</span>
         {{#update_channels}}
           <span>{{{.}}}</span>
@@ -10,9 +10,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/update_overview.mustache
+++ b/_attachments/templates/update_overview.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="channel-selection">
-        <span>Channel: </span>
+        <label>Channel:</label>
         <span>All</span>
         {{#update_channels}}
           <span>{{{.}}}</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>

--- a/_attachments/templates/update_reports.mustache
+++ b/_attachments/templates/update_reports.mustache
@@ -2,7 +2,7 @@
       <legend>Filter</legend>
 
       <div id="branch-selection">
-        <span>Branch:</span>
+        <label>Branch:</label>
         <span>All</span>
         {{#firefox_versions}}
           <span>{{{.}}}</span>
@@ -10,7 +10,7 @@
       </div>
 
       <div id="os-selection">
-        <span>OS: </span>
+        <label>OS:</label>
         <span>All</span>
         <span>Linux</span>
         <span>Mac</span>
@@ -18,9 +18,8 @@
       </div>
 
       <div id="date">
-        <span>From: </span>
-        <input id="start-date" class="datepicker" type="text" value="" size="11" />
-        <span>To: </span>
+        <label>Range:</label>
+        <input id="start-date" class="datepicker" type="text" value="" size="11" /> -
         <input id="end-date" class="datepicker" type="text" value="" size="11" />
       </div>
     </fieldset>


### PR DESCRIPTION
This pull request addresses issue #102, removing click events from Category labels in the Filter. It turns them instead into just regular text. Some additional white space cleanup is included.

Padding was required for the categories since they lost their former span padding. Tested on both Firefox and Chrome and the layout is identical.

Adding @andreieftimie and @whimboo for visibility.
