### PR TITLE
Re-add the highcharts plugin (#112)

### DIFF
--- a/_attachments/index.html
+++ b/_attachments/index.html
@@ -13,6 +13,7 @@
     <script language="javascript" type="text/javascript" src="js/sammy/sammy.js"></script>
     <script language="javascript" type="text/javascript" src="js/sammy/plugins/sammy.mustache.js"></script>
     <script language="javascript" type="text/javascript" src="js/dashboard.js"></script>
+    <script language="javascript" type="text/javascript" src="js/highcharts/highcharts.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
Simple fix for #112
We just re-add the highcharts plugin.

Tested on sandbox and it works as expected: http://mozmill-sandbox.blargon7.com/#/endurance/charts
@whimboo care to take a quick look?
