### PR TITLE
Handle report that misses filename (#116)

### DIFF
--- a/_attachments/js/dashboard.js
+++ b/_attachments/js/dashboard.js
@@ -58,9 +58,10 @@ function processTestResults(aReport) {
   for (var i = 0; i < aReport.results.length; i++) {
     var result = aReport.results[i];
     var info = [ ];
+    var file = result.filename || result.path;
 
     // Split absolute path and only keep the relative path below the test-run folder
-    var parts = result.filename.split(report_type)
+    var parts = file.split(report_type);
     var filename = parts[parts.length - 1].replace(/\\/g, '/');
 
     var repository_url = TESTS_REPOSITORY + '/file/' +


### PR DESCRIPTION
Because of the crash the report didn't contain all information as we would have expected.
Notably we're missing the `filename` entry.

We do have `path` which comes from the original python test object, so we should be good using this.
(If we crash during the test and don't get to update the final object, seems we still have this information available)

Here is the same report mentioned in #116 with this fix:
http://mozmill-sandbox.blargon7.com/#/endurance/report/b4d880bccb8d9ea0732eac8cd85ce73a

@whimboo please review
