### PR TITLE
Update filter for Firefox 34.0 version bump (#117)

### DIFF
--- a/_attachments/js/config.js
+++ b/_attachments/js/config.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var FIREFOX_VERSIONS = ["33.0", "32.0", "31.0", "30.0", "24.0"];
+var FIREFOX_VERSIONS = ["34.0", "33.0", "32.0", "31.0", "24.0"];
 var TESTS_REPOSITORY = "http://hg.mozilla.org/qa/mozmill-tests";
 
 var DASHBOARD_SERVERS = [


### PR DESCRIPTION
This pull request addresses issue #117, updating the dashboard to support the new release of Firefox, adding 34.0 and removing 30.0

Adding @whimboo and @andreieftimie for visibility.
