### PR TITLE
Remove unused servers from config (#120)

### DIFF
--- a/_attachments/js/config.js
+++ b/_attachments/js/config.js
@@ -7,10 +7,8 @@ var TESTS_REPOSITORY = "http://hg.mozilla.org/qa/mozmill-tests";
 
 var DASHBOARD_SERVERS = [
   {urlVal: "mozmill-addons.blargon7.com", titleId: "Add-ons"},
-  {urlVal: "mozmill-ci.blargon7.com", titleId: "CI"},
   {urlVal: "mozmill-crowd.blargon7.com", titleId: "Crowd"},
   {urlVal: "mozmill-daily.blargon7.com", titleId: "Daily"},
-  {urlVal: "mozmill-ondemand.blargon7.com", titleId: "On Demand"},
   {urlVal: "mozmill-release.blargon7.com", titleId: "Release"},
   {urlVal: "mozmill-sandbox.blargon7.com", titleId: "Sandbox"},
   {urlVal: "mozmill-staging.blargon7.com", titleId: "Staging"}


### PR DESCRIPTION
This PR fixes issue #120, removing what @andreieftimie and I believe are unused servers from the config file.

Tested on Windows:
FF Release **30.0**
Chrome Latest Release **35.0.1916.153 m**
