### PR TITLE
Update filter for Firefox 35.0 version bump (#122)

### DIFF
--- a/_attachments/js/config.js
+++ b/_attachments/js/config.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var FIREFOX_VERSIONS = ["34.0", "33.0", "32.0", "31.0", "24.0"];
+var FIREFOX_VERSIONS = ["35.0", "34.0", "33.0", "32.0", "31.0", "24.0"];
 var TESTS_REPOSITORY = "http://hg.mozilla.org/qa/mozmill-tests";
 
 var DASHBOARD_SERVERS = [


### PR DESCRIPTION
This pull request addresses issue #122, updating the dashboard to support the new release of Firefox, adding 35.0 and 'adding' 31.0 (the new ESR) and preserving 24.0 (the old ESR) for one more cycle before 24 is EOL'd.

Adding @whimboo and @andreieftimie for visibility.
