### PR TITLE
Update filter for Firefox 36.0 version bump (#124)

### DIFF
--- a/_attachments/js/config.js
+++ b/_attachments/js/config.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var FIREFOX_VERSIONS = ["35.0", "34.0", "33.0", "32.0", "31.0", "24.0"];
+var FIREFOX_VERSIONS = ["36.0", "35.0", "34.0", "33.0", "31.0"];
 var TESTS_REPOSITORY = "http://hg.mozilla.org/qa/mozmill-tests";
 
 var DASHBOARD_SERVERS = [


### PR DESCRIPTION
This PR addresses issue #124, updating the dashboard filters to support the new release of Firefox: adding 36.0 nightly, removing 32.0 release, and also removing ESR 24.0 which, according to the [previous bump thread by lmandel](https://github.com/mozilla/mozmill-dashboard/issues/122#issuecomment-53075233) is now retired.

Adding @whimboo and @andreieftimie for visibility and review.
