### PR TITLE
Update filter for Firefox 37.0 version bump (#130)

### DIFF
--- a/_attachments/js/config.js
+++ b/_attachments/js/config.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var FIREFOX_VERSIONS = ["36", "35", "34", "33", "31"];
+var FIREFOX_VERSIONS = ["37", "36", "35", "34", "31"];
 
 var UPDATE_CHANNELS = [
   "aurora",
@@ -18,7 +18,6 @@ var UPDATE_CHANNELS = [
   "release",
   "releasetest",
 ];
-
 
 var TESTS_REPOSITORY = "http://hg.mozilla.org/qa/mozmill-tests";
 


### PR DESCRIPTION
This PR addresses issue https://github.com/mozilla/mozmill-dashboard/issues/130, updating the dashboard filters to support the upcoming release of Firefox. Specifically, adding 37.0 nightly, and removing 33.0 release.

Adding @whimboo and @andreieftimie for visibility and review.
