### PR TITLE
Update filter for Firefox 39.0 version bump (#138)

### DIFF
--- a/_attachments/js/config.js
+++ b/_attachments/js/config.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var FIREFOX_VERSIONS = ["38", "37", "36", "35", "31"];
+var FIREFOX_VERSIONS = ["39", "38", "37", "36", "31"];
 
 var UPDATE_CHANNELS = [
   "aurora",


### PR DESCRIPTION
This PR addresses issue #138, updating the dashboard filters to support the upcoming release of Firefox. Specifically, adding 39.0 nightly, and removing 35.0 release.

Adding @whimboo and @andreeamatei for visibility and review.