### PR TITLE
Update filter for Firefox 41.0 version bump (#144)

### DIFF
--- a/_attachments/js/config.js
+++ b/_attachments/js/config.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var FIREFOX_VERSIONS = ["40", "39", "38", "37", "31"];
+var FIREFOX_VERSIONS = ["41", "40", "39", "38", "31"];
 
 var UPDATE_CHANNELS = [
   "aurora", "auroratest",


### PR DESCRIPTION
This PR addresses issue #144, updating the dashboard filters to support the upcoming release of Firefox. Specifically, adding 41.0 nightly, and removing 37.0 release.

Adding @whimboo and @davehunt for visibility and review.
